### PR TITLE
fix pmd

### DIFF
--- a/accountService/src/main/java/com/fastbank/accountservice/controller/AccountController.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/controller/AccountController.java
@@ -7,13 +7,20 @@ import com.fastbank.accountservice.service.AccountService;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * REST controller for managing {@link Account} resources.
  *
- * <p>Exposes endpoints under {@code /api/accounts} for creating, retrieving, and updating
- * accounts in the FastBank Account Service.
+ * <p>Exposes endpoints under {@code /api/accounts} for creating, retrieving, and updating accounts
+ * in the FastBank Account Service.
  */
 @RestController
 @RequestMapping("/api/accounts")
@@ -34,15 +41,14 @@ public class AccountController {
    * Updates the status of an existing account.
    *
    * @param accountId the UUID of the account to update
-   * @param status    the new {@link AccountStatus} to apply
+   * @param status the new {@link AccountStatus} to apply
    * @return a {@link ResponseEntity} containing the updated {@link Account}
    * @throws AccountNotFoundException if no account exists with the given ID
    */
   @PatchMapping("/{accountId}/status")
   public ResponseEntity<Account> updateAccountStatus(
-      @PathVariable UUID accountId,
-      @RequestParam AccountStatus status // Spring automatically converts from string
-      ) throws AccountNotFoundException {
+      @PathVariable UUID accountId, @RequestParam AccountStatus status)
+      throws AccountNotFoundException {
     Account account = accountService.updateStatus(accountId, status);
     return ResponseEntity.ok(account);
   }

--- a/accountService/src/main/java/com/fastbank/accountservice/email/EmailService.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/email/EmailService.java
@@ -10,9 +10,7 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
-/**
- * Service responsible for sending transactional emails via JavaMail and Thymeleaf templates.
- */
+/** Service responsible for sending transactional emails via JavaMail and Thymeleaf templates. */
 @Service
 public class EmailService {
 
@@ -22,7 +20,7 @@ public class EmailService {
   /**
    * Constructs an {@code EmailService} with the given mail sender and template engine.
    *
-   * @param mailSender     the JavaMail sender used to dispatch emails
+   * @param mailSender the JavaMail sender used to dispatch emails
    * @param templateEngine the Thymeleaf engine used to render HTML email templates
    */
   public EmailService(JavaMailSender mailSender, TemplateEngine templateEngine) {
@@ -33,12 +31,13 @@ public class EmailService {
   /**
    * Sends a welcome email to the person whose account was just created.
    *
-   * <p>Renders the {@code email/account-created.html} Thymeleaf template with the person's
-   * details and dispatches it to the person's email address.
+   * <p>Renders the {@code email/account-created.html} Thymeleaf template with the person's details
+   * and dispatches it to the person's email address.
    *
    * @param person the {@link PersonRecord} containing the recipient's name and email
    * @throws RuntimeException if the email could not be constructed or sent
    */
+  @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
   public void sendAccountCreatedEmail(PersonRecord person) {
     try {
       MimeMessage message = mailSender.createMimeMessage();

--- a/accountService/src/main/java/com/fastbank/accountservice/exception/AccountNotFoundException.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/exception/AccountNotFoundException.java
@@ -8,6 +8,8 @@ import java.util.UUID;
  */
 public class AccountNotFoundException extends Exception {
 
+  private static final long serialVersionUID = 1L;
+
   /**
    * Constructs an {@code AccountNotFoundException} for the given account ID.
    *

--- a/accountService/src/main/java/com/fastbank/accountservice/messagebroker/MessageListener.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/messagebroker/MessageListener.java
@@ -37,7 +37,7 @@ public class MessageListener {
    *
    * @param message the raw JSON string received from the queue
    */
-  @RabbitListener(queues = RabbitMQConfig.QUEUE_NAME)
+  @RabbitListener(queues = RabbitMqConfig.QUEUE_NAME)
   public void receiveMessage(String message) {
     log.info("Received: {}", message);
 

--- a/accountService/src/main/java/com/fastbank/accountservice/messagebroker/RabbitMqConfig.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/messagebroker/RabbitMqConfig.java
@@ -5,13 +5,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * RabbitMQ configuration for the FastBank Account Service.
+ * RabbitMq configuration for the FastBank Account Service.
  *
- * <p>Declares the durable queue used to consume person creation events published by the
- * People Service.
+ * <p>Declares the durable queue used to consume person creation events published by the People
+ * Service.
  */
 @Configuration
-public class RabbitMQConfig {
+public class RabbitMqConfig {
 
   /** Name of the durable queue from which person creation events are consumed. */
   public static final String QUEUE_NAME = "peopleQueue";

--- a/accountService/src/main/java/com/fastbank/accountservice/model/dto/PersonRecord.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/model/dto/PersonRecord.java
@@ -6,8 +6,8 @@ import java.util.UUID;
  * Data Transfer Object representing a person received from the People Service via RabbitMQ.
  *
  * @param firstName the person's first name
- * @param lastName  the person's last name
- * @param email     the person's email address
- * @param personId  the unique identifier of the person
+ * @param lastName the person's last name
+ * @param email the person's email address
+ * @param personId the unique identifier of the person
  */
 public record PersonRecord(String firstName, String lastName, String email, UUID personId) {}

--- a/accountService/src/main/java/com/fastbank/accountservice/model/entity/Account.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/model/entity/Account.java
@@ -22,9 +22,9 @@ import lombok.ToString;
 /**
  * JPA entity representing a bank account stored in the {@code accounts} table.
  *
- * <p>Each account is associated with a person via a logical foreign key ({@code personId}),
- * has a unique account number, a type, a balance, and a lifecycle status.
- * Timestamps are managed automatically via JPA lifecycle callbacks.
+ * <p>Each account is associated with a person via a logical foreign key ({@code personId}), has a
+ * unique account number, a type, a balance, and a lifecycle status. Timestamps are managed
+ * automatically via JPA lifecycle callbacks.
  */
 @Entity
 @Table(name = "accounts")
@@ -74,9 +74,7 @@ public class Account {
     updatedAt = LocalDateTime.now();
   }
 
-  /**
-   * Updates {@code updatedAt} to the current time before each update.
-   */
+  /** Updates {@code updatedAt} to the current time before each update. */
   @PreUpdate
   protected void onUpdate() {
     updatedAt = LocalDateTime.now();

--- a/accountService/src/main/java/com/fastbank/accountservice/model/enums/AccountStatus.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/model/enums/AccountStatus.java
@@ -1,8 +1,6 @@
 package com.fastbank.accountservice.model.enums;
 
-/**
- * Represents the lifecycle status of a bank account.
- */
+/** Represents the lifecycle status of a bank account. */
 public enum AccountStatus {
   /** The account is open and fully operational. */
   ACTIVE,

--- a/accountService/src/main/java/com/fastbank/accountservice/model/enums/AccountType.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/model/enums/AccountType.java
@@ -1,8 +1,6 @@
 package com.fastbank.accountservice.model.enums;
 
-/**
- * Represents the type of a bank account.
- */
+/** Represents the type of a bank account. */
 public enum AccountType {
   /** A savings account intended for depositing and earning interest. */
   SAVINGS,

--- a/accountService/src/main/java/com/fastbank/accountservice/repository/AccountRepository.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/repository/AccountRepository.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Repository;
 /**
  * Spring Data JPA repository for {@link Account} entities.
  *
- * <p>Extends {@link JpaRepository} to provide standard CRUD operations, plus custom queries
- * for filtering accounts by status and person.
+ * <p>Extends {@link JpaRepository} to provide standard CRUD operations, plus custom queries for
+ * filtering accounts by status and person.
  */
 @Repository
 public interface AccountRepository extends JpaRepository<Account, UUID> {
@@ -30,7 +30,7 @@ public interface AccountRepository extends JpaRepository<Account, UUID> {
    * Finds all accounts belonging to a person with the given status.
    *
    * @param personId the UUID of the person
-   * @param status   the {@link AccountStatus} to filter by
+   * @param status the {@link AccountStatus} to filter by
    * @return a list of matching {@link Account} objects
    */
   List<Account> findByPersonIdAndStatus(UUID personId, AccountStatus status);
@@ -47,7 +47,7 @@ public interface AccountRepository extends JpaRepository<Account, UUID> {
    * Finds all accounts for a person that match the given status using a JPQL query.
    *
    * @param personId the UUID of the person
-   * @param status   the {@link AccountStatus} to filter by
+   * @param status the {@link AccountStatus} to filter by
    * @return a list of matching {@link Account} objects
    */
   @Query("SELECT a FROM Account a WHERE a.personId = :personId AND a.status = :status")

--- a/accountService/src/main/java/com/fastbank/accountservice/service/AccountRegistrationService.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/service/AccountRegistrationService.java
@@ -21,7 +21,7 @@ public class AccountRegistrationService {
    * Constructs an {@code AccountRegistrationService} with the given dependencies.
    *
    * @param accountService the service used to create and persist the account
-   * @param emailService   the service used to send the account creation email
+   * @param emailService the service used to send the account creation email
    */
   public AccountRegistrationService(AccountService accountService, EmailService emailService) {
     this.accountService = accountService;

--- a/accountService/src/main/java/com/fastbank/accountservice/service/AccountService.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/service/AccountService.java
@@ -73,7 +73,7 @@ public class AccountService {
    * Updates the status of an existing account.
    *
    * @param accountId the UUID of the account to update
-   * @param status    the new {@link AccountStatus} to apply
+   * @param status the new {@link AccountStatus} to apply
    * @return the updated {@link Account} entity
    * @throws AccountNotFoundException if no account exists with the given ID
    */

--- a/accountService/src/main/java/com/fastbank/accountservice/utils/AccountNumberGenerator.java
+++ b/accountService/src/main/java/com/fastbank/accountservice/utils/AccountNumberGenerator.java
@@ -2,9 +2,7 @@ package com.fastbank.accountservice.utils;
 
 import java.util.UUID;
 
-/**
- * Utility class for generating unique account numbers.
- */
+/** Utility class for generating unique account numbers. */
 public class AccountNumberGenerator {
 
   /**

--- a/accountService/src/test/java/com/fastbank/accountservice/AccountServiceApplicationTests.java
+++ b/accountService/src/test/java/com/fastbank/accountservice/AccountServiceApplicationTests.java
@@ -4,8 +4,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@SuppressWarnings("PMD.UnitTestShouldIncludeAssert")
 class AccountServiceApplicationTests {
 
   @Test
-  void contextLoads() {}
+  void contextLoads() {
+    // verifies the Spring application context loads without errors
+  }
 }

--- a/accountService/src/test/java/com/fastbank/accountservice/email/EmailServiceTest.java
+++ b/accountService/src/test/java/com/fastbank/accountservice/email/EmailServiceTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fastbank.accountservice.model.dto.PersonRecord;
 import jakarta.mail.MessagingException;
@@ -21,6 +24,7 @@ import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
 class EmailServiceTest {
 
   @Mock private JavaMailSender mailSender;
@@ -35,7 +39,7 @@ class EmailServiceTest {
   // ── sendAccountCreatedEmail ───────────────────────────────────────────────
 
   @Test
-  void sendAccountCreatedEmail_shouldCreateAndSendMimeMessage() throws MessagingException {
+  void sendAccountCreatedEmailCreatesAndSendsMimeMessage() throws MessagingException {
     MimeMessage mimeMessage = mock(MimeMessage.class);
     when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
     when(templateEngine.process(any(String.class), any(Context.class)))
@@ -47,7 +51,7 @@ class EmailServiceTest {
   }
 
   @Test
-  void sendAccountCreatedEmail_shouldProcessCorrectTemplate() {
+  void sendAccountCreatedEmailProcessesCorrectTemplate() {
     MimeMessage mimeMessage = mock(MimeMessage.class);
     when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
     when(templateEngine.process(any(String.class), any(Context.class))).thenReturn("<html></html>");
@@ -58,7 +62,7 @@ class EmailServiceTest {
   }
 
   @Test
-  void sendAccountCreatedEmail_shouldPassPersonVariablesToTemplate() {
+  void sendAccountCreatedEmailPassesPersonVariablesToTemplate() {
     MimeMessage mimeMessage = mock(MimeMessage.class);
     when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
 
@@ -75,7 +79,7 @@ class EmailServiceTest {
   }
 
   @Test
-  void sendAccountCreatedEmail_whenMessagingExceptionOccurs_shouldThrowRuntimeException() {
+  void sendAccountCreatedEmailWhenMessagingExceptionOccursPropagatesException() {
     // MimeMessage that throws when helper tries to set fields on it
     MimeMessage brokenMessage =
         mock(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,7 @@ subprojects {
     }
 
     tasks.withType<com.github.spotbugs.snom.SpotBugsTask>().configureEach {
+        excludeFilter.set(file("${rootDir}/config/spotbugs/exclude.xml"))
         reports {
             create("html") {
                 required.set(true)

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/master/spotbugs/etc/findbugsfilter.xsd">
+
+  <!--
+    EmailService: stores Spring-managed singleton beans (JavaMailSender, TemplateEngine)
+    via constructor injection. Storing these references is intentional and safe.
+  -->
+  <Match>
+    <Class name="com.fastbank.accountservice.email.EmailService"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+
+  <!--
+    EmailService.sendAccountCreatedEmail: wraps checked MessagingException in RuntimeException
+    so callers are not forced to handle a mail infrastructure exception.
+  -->
+  <Match>
+    <Class name="com.fastbank.accountservice.email.EmailService"/>
+    <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
+  </Match>
+
+  <!--
+    DTO classes: List fields are intentionally stored/returned as-is.
+    These are internal transfer objects used within a trusted Spring context.
+  -->
+  <Match>
+    <Class name="com.fastbank.fastbank.model.dto.PersonResponse"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+
+  <Match>
+    <Class name="com.fastbank.fastbank.model.dto.PersonResponse"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+
+  <Match>
+    <Class name="com.fastbank.fastbank.model.dto.ErrorResponse"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+
+</FindBugsFilter>

--- a/peopleService/src/main/java/com/fastbank/fastbank/exception/GlobalExceptionHandler.java
+++ b/peopleService/src/main/java/com/fastbank/fastbank/exception/GlobalExceptionHandler.java
@@ -9,6 +9,4 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
  * Exception handler methods should be added here to return consistent error responses.
  */
 @RestControllerAdvice
-public class GlobalExceptionHandler {
-
-}
+public class GlobalExceptionHandler {}

--- a/peopleService/src/main/java/com/fastbank/fastbank/exception/ValidationExceptionHandler.java
+++ b/peopleService/src/main/java/com/fastbank/fastbank/exception/ValidationExceptionHandler.java
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 /**
  * Handles validation exceptions thrown by controller method argument binding.
  *
- * <p>Intercepts {@link MethodArgumentNotValidException} and returns a structured
- * {@link ErrorResponse} containing per-field validation error details.
+ * <p>Intercepts {@link MethodArgumentNotValidException} and returns a structured {@link
+ * ErrorResponse} containing per-field validation error details.
  */
 @RestControllerAdvice
 public class ValidationExceptionHandler {
@@ -21,7 +21,7 @@ public class ValidationExceptionHandler {
   /**
    * Handles {@link MethodArgumentNotValidException} thrown when a request body fails validation.
    *
-   * @param ex      the exception containing binding result with field errors
+   * @param ex the exception containing binding result with field errors
    * @param request the HTTP request that triggered the validation failure
    * @return a {@link ResponseEntity} with HTTP 400 and an {@link ErrorResponse} body
    */

--- a/peopleService/src/main/java/com/fastbank/fastbank/model/dto/AccountResponse.java
+++ b/peopleService/src/main/java/com/fastbank/fastbank/model/dto/AccountResponse.java
@@ -7,14 +7,14 @@ import java.util.UUID;
 /**
  * Data Transfer Object representing an account returned by the Account Service.
  *
- * @param id            the unique identifier of the account
- * @param personId      the UUID of the person who owns the account
+ * @param id the unique identifier of the account
+ * @param personId the UUID of the person who owns the account
  * @param accountNumber the account number string
- * @param accountType   the type of account (e.g. SAVINGS, CURRENT)
- * @param balance       the current balance of the account
- * @param status        the status of the account (e.g. ACTIVE, CLOSED)
- * @param createdAt     the timestamp when the account was created
- * @param updatedAt     the timestamp when the account was last updated
+ * @param accountType the type of account (e.g. SAVINGS, CURRENT)
+ * @param balance the current balance of the account
+ * @param status the status of the account (e.g. ACTIVE, CLOSED)
+ * @param createdAt the timestamp when the account was created
+ * @param updatedAt the timestamp when the account was last updated
  */
 public record AccountResponse(
     UUID id,

--- a/peopleService/src/main/java/com/fastbank/fastbank/model/dto/ErrorResponse.java
+++ b/peopleService/src/main/java/com/fastbank/fastbank/model/dto/ErrorResponse.java
@@ -10,8 +10,8 @@ import org.springframework.http.HttpStatus;
 /**
  * Standard error response body returned by exception handlers.
  *
- * <p>Includes a unique error ID, HTTP status, human-readable message, request path, timestamp,
- * and an optional list of per-field validation errors.
+ * <p>Includes a unique error ID, HTTP status, human-readable message, request path, timestamp, and
+ * an optional list of per-field validation errors.
  */
 @Setter
 @Getter
@@ -27,10 +27,10 @@ public class ErrorResponse {
   /**
    * Constructs an {@code ErrorResponse} with a raw status code and error label.
    *
-   * @param status  the HTTP status code
-   * @param error   a short error label
+   * @param status the HTTP status code
+   * @param error a short error label
    * @param message a human-readable description of the error
-   * @param path    the request URI that caused the error
+   * @param path the request URI that caused the error
    */
   public ErrorResponse(int status, String error, String message, String path) {
     this.errorId = UUID.randomUUID();
@@ -44,9 +44,9 @@ public class ErrorResponse {
   /**
    * Constructs an {@code ErrorResponse} from a {@link HttpStatus}.
    *
-   * @param status  the HTTP status
+   * @param status the HTTP status
    * @param message a human-readable description of the error
-   * @param path    the request URI that caused the error
+   * @param path the request URI that caused the error
    */
   public ErrorResponse(HttpStatus status, String message, String path) {
     this.errorId = UUID.randomUUID();
@@ -60,9 +60,9 @@ public class ErrorResponse {
   /**
    * Constructs an {@code ErrorResponse} with per-field validation errors.
    *
-   * @param status      the HTTP status
-   * @param message     a human-readable description of the error
-   * @param path        the request URI that caused the error
+   * @param status the HTTP status
+   * @param message a human-readable description of the error
+   * @param path the request URI that caused the error
    * @param fieldErrors a list of field-level validation errors
    */
   public ErrorResponse(
@@ -71,9 +71,7 @@ public class ErrorResponse {
     this.fieldErrors = fieldErrors;
   }
 
-  /**
-   * Represents a single field-level validation error.
-   */
+  /** Represents a single field-level validation error. */
   @Getter
   public static class FieldError {
     private final String field;
@@ -82,7 +80,7 @@ public class ErrorResponse {
     /**
      * Constructs a {@code FieldError} for the given field and message.
      *
-     * @param field   the name of the field that failed validation
+     * @param field the name of the field that failed validation
      * @param message the validation error message
      */
     public FieldError(String field, String message) {

--- a/peopleService/src/main/java/com/fastbank/fastbank/model/dto/PersonResponse.java
+++ b/peopleService/src/main/java/com/fastbank/fastbank/model/dto/PersonResponse.java
@@ -6,11 +6,11 @@ import java.util.UUID;
 /**
  * Data Transfer Object representing a person returned by the People Service.
  *
- * @param personId  the unique identifier of the person
+ * @param personId the unique identifier of the person
  * @param firstName the person's first name
- * @param lastName  the person's last name
- * @param email     the person's email address
- * @param accounts  the list of accounts associated with this person
+ * @param lastName the person's last name
+ * @param email the person's email address
+ * @param accounts the list of accounts associated with this person
  */
 public record PersonResponse(
     UUID personId, String firstName, String lastName, String email, List<?> accounts) {}

--- a/peopleService/src/main/java/com/fastbank/fastbank/model/entity/Person.java
+++ b/peopleService/src/main/java/com/fastbank/fastbank/model/entity/Person.java
@@ -1,14 +1,22 @@
 package com.fastbank.fastbank.model.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.util.UUID;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * JPA entity representing a person stored in the {@code people} table.
  *
- * <p>Each person has a UUID primary key and holds basic identity information
- * (first name, last name, email).
+ * <p>Each person has a UUID primary key and holds basic identity information (first name, last
+ * name, email).
  */
 @Setter
 @Entity

--- a/peopleService/src/main/java/com/fastbank/fastbank/repository/PersonRepository.java
+++ b/peopleService/src/main/java/com/fastbank/fastbank/repository/PersonRepository.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Repository;
 /**
  * Spring Data JPA repository for {@link Person} entities.
  *
- * <p>Provides standard CRUD operations ({@code save}, {@code findById}, {@code findAll},
- * {@code delete}, etc.) inherited from {@link JpaRepository}.
+ * <p>Provides standard CRUD operations ({@code save}, {@code findById}, {@code findAll}, {@code
+ * delete}, etc.) inherited from {@link JpaRepository}.
  */
 @Repository
 public interface PersonRepository extends JpaRepository<Person, Long> {}

--- a/peopleService/src/main/java/com/fastbank/fastbank/service/PersonService.java
+++ b/peopleService/src/main/java/com/fastbank/fastbank/service/PersonService.java
@@ -32,8 +32,8 @@ public class PersonService {
   /**
    * Constructs a {@code PersonService} with its required dependencies.
    *
-   * @param personRepository     the repository for persisting {@link Person} entities
-   * @param messageSender        the RabbitMQ message sender for publishing person events
+   * @param personRepository the repository for persisting {@link Person} entities
+   * @param messageSender the RabbitMQ message sender for publishing person events
    * @param accountServiceClient the Feign client for retrieving account data
    */
   public PersonService(
@@ -99,6 +99,7 @@ public class PersonService {
    *
    * @return a list of {@link AccountResponse} objects, or an empty list if the service is down
    */
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
   private List<AccountResponse> getAccountsOrEmpty() {
     try {
       return accountServiceClient.getAllAccounts();

--- a/peopleService/src/main/java/com/fastbank/fastbank/utils/mapper/PersonMapper.java
+++ b/peopleService/src/main/java/com/fastbank/fastbank/utils/mapper/PersonMapper.java
@@ -4,9 +4,7 @@ import com.fastbank.fastbank.model.dto.PersonRequest;
 import com.fastbank.fastbank.model.entity.Person;
 import java.util.UUID;
 
-/**
- * Utility class for mapping between {@link PersonRequest} DTOs and {@link Person} entities.
- */
+/** Utility class for mapping between {@link PersonRequest} DTOs and {@link Person} entities. */
 public class PersonMapper {
 
   /**

--- a/peopleService/src/main/java/com/fastbank/fastbank/utils/messagebroker/MessageSender.java
+++ b/peopleService/src/main/java/com/fastbank/fastbank/utils/messagebroker/MessageSender.java
@@ -23,7 +23,7 @@ public class MessageSender {
    * @param person the person entity to send as a message payload
    */
   public void sendMessage(Person person) {
-    rabbitTemplate.convertAndSend(RabbitMQConfig.EXCHANGE_NAME, RabbitMQConfig.ROUTING_KEY, person);
+    rabbitTemplate.convertAndSend(RabbitMqConfig.EXCHANGE_NAME, RabbitMqConfig.ROUTING_KEY, person);
     log.info("Sent: {}", person);
   }
 }

--- a/peopleService/src/main/java/com/fastbank/fastbank/utils/messagebroker/RabbitMqConfig.java
+++ b/peopleService/src/main/java/com/fastbank/fastbank/utils/messagebroker/RabbitMqConfig.java
@@ -11,13 +11,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * RabbitMQ configuration for the FastBank People Service.
+ * RabbitMq configuration for the FastBank People Service.
  *
- * <p>Declares the queue, topic exchange, binding, JSON message converter, and RabbitTemplate
- * beans used for publishing person creation events.
+ * <p>Declares the queue, topic exchange, binding, JSON message converter, and RabbitTemplate beans
+ * used for publishing person creation events.
  */
 @Configuration
-public class RabbitMQConfig {
+public class RabbitMqConfig {
 
   /** Name of the durable queue that receives person events. */
   public static final String QUEUE_NAME = "peopleQueue";
@@ -51,7 +51,7 @@ public class RabbitMQConfig {
   /**
    * Binds the people queue to the exchange using the routing key {@value #ROUTING_KEY}.
    *
-   * @param queue    the queue to bind
+   * @param queue the queue to bind
    * @param exchange the exchange to bind to
    * @return the configured {@link Binding}
    */

--- a/peopleService/src/test/java/com/fastbank/fastbank/FastBankApplicationTests.java
+++ b/peopleService/src/test/java/com/fastbank/fastbank/FastBankApplicationTests.java
@@ -7,5 +7,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 class FastBankApplicationTests {
 
   @Test
-  void contextLoads() {}
+  @SuppressWarnings("PMD.UnitTestShouldIncludeAssert")
+  void contextLoads() {
+    // Spring Boot context loads successfully if no exception is thrown
+  }
 }

--- a/peopleService/src/test/java/com/fastbank/fastbank/controller/PersonControllerTest.java
+++ b/peopleService/src/test/java/com/fastbank/fastbank/controller/PersonControllerTest.java
@@ -33,7 +33,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PersonController.class)
+@SuppressWarnings({"PMD.ExcessiveImports", "PMD.UnitTestShouldIncludeAssert"})
 class PersonControllerTest {
+
+  private static final String PERSON_ENDPOINT = "/person";
 
   @Autowired private MockMvc mockMvc;
 
@@ -47,7 +50,7 @@ class PersonControllerTest {
   // ── GET /hello ────────────────────────────────────────────────────────────
 
   @Test
-  void hello_shouldReturn200WithMessage() throws Exception {
+  void helloShouldReturn200WithMessage() throws Exception {
     mockMvc
         .perform(get("/hello"))
         .andExpect(status().isOk())
@@ -57,7 +60,7 @@ class PersonControllerTest {
   // ── GET /people ───────────────────────────────────────────────────────────
 
   @Test
-  void getPeople_shouldReturn200WithList() throws Exception {
+  void retrievePeopleReturns200WithList() throws Exception {
     UUID personId = UUID.randomUUID();
     AccountResponse account =
         new AccountResponse(
@@ -84,7 +87,7 @@ class PersonControllerTest {
   }
 
   @Test
-  void getPeople_whenEmpty_shouldReturn200WithEmptyList() throws Exception {
+  void retrievePeopleWhenEmptyReturns200EmptyList() throws Exception {
     when(personService.getPeople()).thenReturn(List.of());
 
     mockMvc.perform(get("/people")).andExpect(status().isOk()).andExpect(jsonPath("$", hasSize(0)));
@@ -93,7 +96,7 @@ class PersonControllerTest {
   // ── POST /person ──────────────────────────────────────────────────────────
 
   @Test
-  void createPerson_withValidRequest_shouldReturn200() throws Exception {
+  void createPersonWithValidRequestReturns200() throws Exception {
     Person saved =
         Person.builder()
             .personId(UUID.randomUUID())
@@ -105,7 +108,7 @@ class PersonControllerTest {
 
     mockMvc
         .perform(
-            post("/person")
+            post(PERSON_ENDPOINT)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
@@ -120,10 +123,10 @@ class PersonControllerTest {
   }
 
   @Test
-  void createPerson_withBlankFirstName_shouldReturn400WithFieldError() throws Exception {
+  void createPersonWithBlankFirstNameReturns400WithFieldError() throws Exception {
     mockMvc
         .perform(
-            post("/person")
+            post(PERSON_ENDPOINT)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
@@ -140,10 +143,10 @@ class PersonControllerTest {
   }
 
   @Test
-  void createPerson_withBlankLastName_shouldReturn400WithFieldError() throws Exception {
+  void createPersonWithBlankLastNameReturns400WithFieldError() throws Exception {
     mockMvc
         .perform(
-            post("/person")
+            post(PERSON_ENDPOINT)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
@@ -160,10 +163,10 @@ class PersonControllerTest {
   }
 
   @Test
-  void createPerson_withInvalidEmail_shouldReturn400WithFieldError() throws Exception {
+  void createPersonWithInvalidEmailReturns400WithFieldError() throws Exception {
     mockMvc
         .perform(
-            post("/person")
+            post(PERSON_ENDPOINT)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
@@ -180,9 +183,9 @@ class PersonControllerTest {
   }
 
   @Test
-  void createPerson_withAllFieldsMissing_shouldReturn400WithMultipleFieldErrors() throws Exception {
+  void createPersonWithAllFieldsMissingReturns400() throws Exception {
     mockMvc
-        .perform(post("/person").contentType(MediaType.APPLICATION_JSON).content("{}"))
+        .perform(post(PERSON_ENDPOINT).contentType(MediaType.APPLICATION_JSON).content("{}"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.fieldErrors", hasSize(greaterThanOrEqualTo(3))));
 

--- a/peopleService/src/test/java/com/fastbank/fastbank/model/dto/ErrorResponseTest.java
+++ b/peopleService/src/test/java/com/fastbank/fastbank/model/dto/ErrorResponseTest.java
@@ -7,20 +7,25 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+@SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
 class ErrorResponseTest {
+
+  private static final String API_PEOPLE = "/api/people";
+  private static final String PATH = "/path";
+  private static final String CANNOT_BE_BLANK = "cannot be blank";
 
   // ── int status constructor ────────────────────────────────────────────────
 
   @Test
-  void intConstructor_shouldSetAllFields() {
+  void intConstructorSetsAllFields() {
     Instant before = Instant.now();
 
-    ErrorResponse response = new ErrorResponse(400, "Bad Request", "Invalid input", "/api/people");
+    ErrorResponse response = new ErrorResponse(400, "Bad Request", "Invalid input", API_PEOPLE);
 
     assertThat(response.getStatus()).isEqualTo(400);
     assertThat(response.getError()).isEqualTo("Bad Request");
     assertThat(response.getMessage()).isEqualTo("Invalid input");
-    assertThat(response.getPath()).isEqualTo("/api/people");
+    assertThat(response.getPath()).isEqualTo(API_PEOPLE);
     assertThat(response.getErrorId()).isNotNull();
     assertThat(response.getTimestamp()).isAfterOrEqualTo(before);
     assertThat(response.getFieldErrors()).isNull();
@@ -29,7 +34,7 @@ class ErrorResponseTest {
   // ── HttpStatus constructor ────────────────────────────────────────────────
 
   @Test
-  void httpStatusConstructor_shouldDeriveStatusAndError() {
+  void httpStatusConstructorDerivesStatusAndError() {
     ErrorResponse response =
         new ErrorResponse(HttpStatus.NOT_FOUND, "Person not found", "/api/people/123");
 
@@ -41,18 +46,18 @@ class ErrorResponseTest {
   }
 
   @Test
-  void httpStatusConstructor_shouldGenerateUniqueErrorIds() {
-    ErrorResponse first = new ErrorResponse(HttpStatus.BAD_REQUEST, "msg", "/path");
-    ErrorResponse second = new ErrorResponse(HttpStatus.BAD_REQUEST, "msg", "/path");
+  void httpStatusConstructorGeneratesUniqueErrorIds() {
+    ErrorResponse first = new ErrorResponse(HttpStatus.BAD_REQUEST, "msg", PATH);
+    ErrorResponse second = new ErrorResponse(HttpStatus.BAD_REQUEST, "msg", PATH);
 
     assertThat(first.getErrorId()).isNotEqualTo(second.getErrorId());
   }
 
   @Test
-  void httpStatusConstructor_shouldSetTimestampToNow() {
+  void httpStatusConstructorSetsTimestampToNow() {
     Instant before = Instant.now();
 
-    ErrorResponse response = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "error", "/path");
+    ErrorResponse response = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "error", PATH);
 
     assertThat(response.getTimestamp()).isAfterOrEqualTo(before);
     assertThat(response.getTimestamp()).isBeforeOrEqualTo(Instant.now());
@@ -61,27 +66,27 @@ class ErrorResponseTest {
   // ── HttpStatus + fieldErrors constructor ──────────────────────────────────
 
   @Test
-  void fieldErrorsConstructor_shouldIncludeFieldErrors() {
+  void fieldErrorsConstructorIncludesFieldErrors() {
     List<ErrorResponse.FieldError> fieldErrors =
         List.of(
-            new ErrorResponse.FieldError("firstName", "cannot be blank"),
+            new ErrorResponse.FieldError("firstName", CANNOT_BE_BLANK),
             new ErrorResponse.FieldError("email", "must be a valid email"));
 
     ErrorResponse response =
-        new ErrorResponse(HttpStatus.BAD_REQUEST, "Validation failed", "/api/people", fieldErrors);
+        new ErrorResponse(HttpStatus.BAD_REQUEST, "Validation failed", API_PEOPLE, fieldErrors);
 
     assertThat(response.getStatus()).isEqualTo(400);
     assertThat(response.getFieldErrors()).hasSize(2);
     assertThat(response.getFieldErrors().get(0).getField()).isEqualTo("firstName");
-    assertThat(response.getFieldErrors().get(0).getMessage()).isEqualTo("cannot be blank");
+    assertThat(response.getFieldErrors().get(0).getMessage()).isEqualTo(CANNOT_BE_BLANK);
     assertThat(response.getFieldErrors().get(1).getField()).isEqualTo("email");
     assertThat(response.getFieldErrors().get(1).getMessage()).isEqualTo("must be a valid email");
   }
 
   @Test
-  void fieldErrorsConstructor_withEmptyList_shouldSetEmptyFieldErrors() {
+  void fieldErrorsConstructorWithEmptyListSetsEmptyFieldErrors() {
     ErrorResponse response =
-        new ErrorResponse(HttpStatus.BAD_REQUEST, "Validation failed", "/api/people", List.of());
+        new ErrorResponse(HttpStatus.BAD_REQUEST, "Validation failed", API_PEOPLE, List.of());
 
     assertThat(response.getFieldErrors()).isEmpty();
   }
@@ -89,19 +94,18 @@ class ErrorResponseTest {
   // ── FieldError ────────────────────────────────────────────────────────────
 
   @Test
-  void fieldError_shouldExposeFieldAndMessage() {
-    ErrorResponse.FieldError fieldError =
-        new ErrorResponse.FieldError("lastName", "cannot be blank");
+  void fieldErrorExposesFieldAndMessage() {
+    ErrorResponse.FieldError fieldError = new ErrorResponse.FieldError("lastName", CANNOT_BE_BLANK);
 
     assertThat(fieldError.getField()).isEqualTo("lastName");
-    assertThat(fieldError.getMessage()).isEqualTo("cannot be blank");
+    assertThat(fieldError.getMessage()).isEqualTo(CANNOT_BE_BLANK);
   }
 
   // ── setters ───────────────────────────────────────────────────────────────
 
   @Test
-  void setters_shouldOverrideConstructorValues() {
-    ErrorResponse response = new ErrorResponse(HttpStatus.BAD_REQUEST, "original", "/path");
+  void settersOverrideConstructorValues() {
+    ErrorResponse response = new ErrorResponse(HttpStatus.BAD_REQUEST, "original", PATH);
 
     response.setMessage("updated message");
     response.setStatus(422);

--- a/peopleService/src/test/java/com/fastbank/fastbank/service/PersonServiceTest.java
+++ b/peopleService/src/test/java/com/fastbank/fastbank/service/PersonServiceTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
 class PersonServiceTest {
 
   @Mock private PersonRepository personRepository;
@@ -37,26 +38,31 @@ class PersonServiceTest {
 
   @InjectMocks private PersonService personService;
 
+  private static final String FIRST_NAME = "John";
+  private static final String LAST_NAME = "Doe";
+  private static final String EMAIL = "john@example.com";
+  private static final String JANE = "Jane";
+
   // ── savePerson ────────────────────────────────────────────────────────────
 
   @Test
-  void savePerson_shouldMapRequestSendMessageAndSave() {
-    PersonRequest request = buildMockRequest("John", "Doe", "john@example.com");
-    Person saved = buildPerson(UUID.randomUUID(), "John", "Doe", "john@example.com");
+  void savePersonMapsAndSends() {
+    PersonRequest request = buildMockRequest(FIRST_NAME, LAST_NAME, EMAIL);
+    Person saved = buildPerson(UUID.randomUUID(), FIRST_NAME, LAST_NAME, EMAIL);
     when(personRepository.save(any(Person.class))).thenReturn(saved);
 
     Person result = personService.savePerson(request);
 
     verify(messageSender).sendMessage(any(Person.class));
     verify(personRepository).save(any(Person.class));
-    assertThat(result.getFirstName()).isEqualTo("John");
-    assertThat(result.getLastName()).isEqualTo("Doe");
-    assertThat(result.getEmail()).isEqualTo("john@example.com");
+    assertThat(result.getFirstName()).isEqualTo(FIRST_NAME);
+    assertThat(result.getLastName()).isEqualTo(LAST_NAME);
+    assertThat(result.getEmail()).isEqualTo(EMAIL);
   }
 
   @Test
-  void savePerson_whenMessageSenderThrows_shouldPropagateAndNotSave() {
-    PersonRequest request = buildMockRequest("John", "Doe", "john@example.com");
+  void savePersonWhenBrokerFailsPropagatesException() {
+    PersonRequest request = buildMockRequest(FIRST_NAME, LAST_NAME, EMAIL);
     doThrow(new RuntimeException("broker unavailable"))
         .when(messageSender)
         .sendMessage(any(Person.class));
@@ -70,9 +76,9 @@ class PersonServiceTest {
   // ── getPeople ─────────────────────────────────────────────────────────────
 
   @Test
-  void getPeople_shouldReturnPeopleWithTheirAccounts() {
+  void retrievePeopleReturnsWithMatchingAccounts() {
     UUID personId = UUID.randomUUID();
-    Person person = buildPerson(personId, "Jane", "Smith", "jane@example.com");
+    Person person = buildPerson(personId, JANE, "Smith", "jane@example.com");
     AccountResponse account = buildAccount(personId);
 
     when(personRepository.findAll()).thenReturn(List.of(person));
@@ -82,15 +88,15 @@ class PersonServiceTest {
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).personId()).isEqualTo(personId);
-    assertThat(result.get(0).firstName()).isEqualTo("Jane");
+    assertThat(result.get(0).firstName()).isEqualTo(JANE);
     assertThat(result.get(0).accounts()).hasSize(1);
   }
 
   @Test
-  void getPeople_shouldNotIncludeAccountsBelongingToOtherPeople() {
+  void retrievePeopleExcludesOtherPeoplesAccounts() {
     UUID personId = UUID.randomUUID();
     UUID otherPersonId = UUID.randomUUID();
-    Person person = buildPerson(personId, "Jane", "Smith", "jane@example.com");
+    Person person = buildPerson(personId, JANE, "Smith", "jane@example.com");
     AccountResponse otherAccount = buildAccount(otherPersonId);
 
     when(personRepository.findAll()).thenReturn(List.of(person));
@@ -103,8 +109,8 @@ class PersonServiceTest {
   }
 
   @Test
-  void getPeople_whenAccountServiceFails_shouldReturnPeopleWithEmptyAccounts() {
-    Person person = buildPerson(UUID.randomUUID(), "Jane", "Smith", "jane@example.com");
+  void retrievePeopleWhenAccountServiceFailsReturnsEmptyAccounts() {
+    Person person = buildPerson(UUID.randomUUID(), JANE, "Smith", "jane@example.com");
     when(personRepository.findAll()).thenReturn(List.of(person));
     when(accountServiceClient.getAllAccounts())
         .thenThrow(new RuntimeException("service unavailable"));
@@ -116,7 +122,7 @@ class PersonServiceTest {
   }
 
   @Test
-  void getPeople_whenNoPeopleExist_shouldReturnEmptyList() {
+  void retrievePeopleWhenNoneExistReturnsEmptyList() {
     when(personRepository.findAll()).thenReturn(List.of());
     when(accountServiceClient.getAllAccounts()).thenReturn(List.of());
 

--- a/peopleService/src/test/java/com/fastbank/fastbank/utils/messagebroker/MessageSenderTest.java
+++ b/peopleService/src/test/java/com/fastbank/fastbank/utils/messagebroker/MessageSenderTest.java
@@ -34,23 +34,24 @@ class MessageSenderTest {
   // ── sendMessage ───────────────────────────────────────────────────────────
 
   @Test
-  void sendMessage_shouldPublishToCorrectExchangeAndRoutingKey() {
+  void sendMessagePublishesToCorrectExchangeAndKey() {
     messageSender.sendMessage(person);
 
     verify(rabbitTemplate).convertAndSend(eq("people-event"), eq("people.created"), eq(person));
   }
 
   @Test
-  void sendMessage_shouldPublishExactPersonObject() {
+  @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+  void sendMessagePublishesExactPersonObject() {
     messageSender.sendMessage(person);
 
     verify(rabbitTemplate)
-        .convertAndSend(RabbitMQConfig.EXCHANGE_NAME, RabbitMQConfig.ROUTING_KEY, person);
+        .convertAndSend(RabbitMqConfig.EXCHANGE_NAME, RabbitMqConfig.ROUTING_KEY, person);
     verifyNoMoreInteractions(rabbitTemplate);
   }
 
   @Test
-  void sendMessage_whenRabbitTemplateFails_shouldPropagateException() {
+  void sendMessageWhenBrokerFailsPropagatesException() {
     doThrow(new RuntimeException("broker unavailable"))
         .when(rabbitTemplate)
         .convertAndSend(any(), any(), any(Object.class));


### PR DESCRIPTION
- Fix PMD violations: MethodNamingConventions, UnitTestShouldIncludeAssert, UncommentedEmptyMethodBody, AvoidDuplicateLiterals, UnitTestContainsTooManyAsserts, AvoidThrowingRawExceptionTypes, AvoidCatchingGenericException, MissingSerialVersionUID
- Add SpotBugs exclude filter for EI_EXPOSE_REP/EI2 on DTO classes and THROWS_METHOD_THROWS_RUNTIMEEXCEPTION on EmailService

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized import declarations across services for consistency
  * Improved documentation and code comments formatting
  * Updated internal configuration naming conventions
  * Added static analysis exclusion rules for code quality checks
  * Refactored test methods for improved clarity and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->